### PR TITLE
feat: orb と card にベゼル/フレーム表現を追加

### DIFF
--- a/style.css
+++ b/style.css
@@ -223,6 +223,22 @@ body{
   /* -webkit-backdrop-filter: blur(16px); */
   /* backdrop-filter: blur(16px); */
   border: 1px solid var(--border);
+  /* フレーム表現：フレーム帯 + 面取り */
+  box-shadow:
+    /* ── 外側から順に ── */
+    /* 1. 外縁暗線（カード全体の境界） */
+    0 0 0 0.5px rgba(22,22,26,.1),
+    /* 2. フレーム帯ハイライト（上寄せ、厚みの光沢面） */
+    0 -0.5px 0 2px rgba(255,255,255,.2),
+    /* 3. フレーム帯本体（薄いトーン、約4px幅） */
+    0 0 0 6px rgba(248, 245, 252, 0.42),
+    /* 4. 隙間線（フレーム帯の内側境界） */
+    0 0 0 7px rgba(22,22,26,.055),
+    /* ── 内側 ── */
+    /* 5. 内縁ハイライト（面取り、上寄せ） */
+    inset 0 1px 0 1px rgba(255,255,255,.28),
+    /* 6. 内側沈み影（フレームに沈む感じ） */
+    inset 0 2px 5px rgba(22,22,26,.04);
   backface-visibility:hidden;
   -webkit-backface-visibility: hidden;
   transform-style:preserve-3d;
@@ -536,8 +552,15 @@ a:hover::after{
     radial-gradient(60% 50% at 50% 45%, rgba(255,160,200,calc(var(--orb-aurora-opacity) * 0.4)) 0 18%, transparent 42%),
     radial-gradient(circle at 50% 50%, rgba(232,242,255,.82), rgba(222,235,250,.55) 50%, rgba(205,220,242,.38) 100%);
   box-shadow:
+    /* 内側ハイライト（既存） */
     inset 0 0 0 1px rgba(255,255,255,.7),
+    /* 内側下部の影（既存） */
     inset 0 -6px 14px rgba(22,22,26,.22),
+    /* ベゼル内縁：薄いハイライト（面取り感） */
+    0 0 0 0.5px rgba(255,255,255,.18),
+    /* 外周暗線：隙間感（部品境界） */
+    0 0 0 1.25px rgba(22,22,26,.2),
+    /* 外側の影（既存） */
     0 6px 14px rgba(22,22,26,.22);
   transition: transform .2s ease, box-shadow .2s ease;
 }
@@ -584,6 +607,8 @@ a:hover::after{
   box-shadow:
     inset 0 0 0 1px rgba(255,255,255,.7),
     inset 0 -4px 8px rgba(22,22,26,.14),
+    0 0 0 0.5px rgba(255,255,255,.18),
+    0 0 0 1.25px rgba(22,22,26,.2),
     0 8px 14px rgba(22,22,26,.2);
 }
 
@@ -610,6 +635,8 @@ a:hover::after{
     0 0 0 4px rgba(216,90,166,.45),
     inset 0 0 0 1px rgba(255,255,255,.7),
     inset 0 -4px 8px rgba(22,22,26,.12),
+    0 0 0 0.5px rgba(255,255,255,.18),
+    0 0 0 1.25px rgba(22,22,26,.2),
     0 8px 16px rgba(22,22,26,.18);
 }
 


### PR DESCRIPTION
## Summary

- orb 外周に暗線(1.25px)とハイライト(0.5px)を追加し「部品として収まっている」感を強化
- card 外周に約4px幅のフレーム帯を追加し「ポケモンカード的なトイ感」を演出
- 上方向光源を意識した非対称ハイライトで素材感のある縁取りを実現

## Test plan

- [ ] orb の縁が「筐体に嵌まった部品」として見えるか確認
- [ ] card の縁が「1〜2mmのフレーム帯」として量感があるか確認
- [ ] hover / focus-visible 状態でベゼル表現が維持されるか確認
- [ ] 縮小表示でも輪郭の気配が残っているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)