### PR TITLE
feat: shelf foundation (mode detection + disable flip) (#46)

### DIFF
--- a/js/card.js
+++ b/js/card.js
@@ -269,7 +269,15 @@
     const hash = location.hash.toLowerCase();
     setIllustPeek(false, { returnFocus: true });
     if (hash === "#code") {
-      setState(true, { updateHash: false, moveFocus: true, fallbackFocusEl: orbToggle });
+      // 棚モード中は #code を無視し、表の状態に寄せる
+      if (isPcShelfMode()) {
+        if (history.replaceState) {
+          history.replaceState(null, "", location.pathname + location.search);
+        }
+        setState(false, { updateHash: false, moveFocus: true, fallbackFocusEl: orbToggle });
+      } else {
+        setState(true, { updateHash: false, moveFocus: true, fallbackFocusEl: orbToggle });
+      }
     } else if (hash === "#gallery") {
       setState(false, { updateHash: false, moveFocus: true, fallbackFocusEl: orbToggle });
     } else if (hash === "" || hash === "#") {
@@ -293,6 +301,9 @@
 
   syncFromHash();
   window.addEventListener("hashchange", syncFromHash);
+
+  // 棚モード判定を外部公開（#47 #48 から参照可能）
+  window.wkIsPcShelfMode = isPcShelfMode;
 
   // --- Card Tilt (pointer-driven) ---
   // Reuse `card` (wkCard = .wk-card-rotator) defined at the top of this IIFE.


### PR DESCRIPTION
## Summary
- PC棚モード判定を `matchMedia("(hover:hover) and (pointer:fine) and (min-width:800px)")` で実装
- `isPcShelfMode()` 関数を追加（他の sub issue #47 #48 から参照可能）
- 棚モード時は flip（表裏切替）を無効化（3箇所でガード）
- 非PC環境では既存のflip動作を維持

## Test plan
- [ ] PC（hover対応 + 精密ポインタ + 幅800px以上）でアクセス時、Orb/Codeボタンをクリックしてもflipしないこと
- [ ] タッチデバイスまたは幅800px未満でアクセス時、既存のflip動作が正常に動作すること
- [ ] ブラウザのDevToolsでデバイスモードを切り替えてリロードし、判定が正しく切り替わること

## Scope
- このPRは #46 のスコープのみ（モード判定 + flip無効化）
- レイアウト調整、UI要素の表示/非表示、タグ実装は #47 #48 で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)