### PR TITLE
スマホ向けカードを憲法に沿って整列

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
                       </div>
                       <div class="wk-portal" id="wkIllustPeek" hidden role="region" aria-label="Illustration preview" tabindex="-1" data-shelf-hide>
                         <div class="wk-portal-inner wk-deck" data-wk-deck="illust" data-wk-action="preview">
-                          <img src="thumbnail_illust.jpg" alt="Illustration preview 01" class="wk-portal-image wk-deck-card" data-deck-index="0" role="button" tabindex="0" aria-pressed="false">
-                          <img src="thumbnail_illust2.jpg" alt="Illustration preview 02" class="wk-portal-image wk-deck-card" data-deck-index="1" role="button" tabindex="0" aria-pressed="false">
+                          <img src="thumbnail_illust.jpg" alt="Illustration preview 01" class="card wk-portal-image wk-deck-card" data-deck-index="0" role="button" tabindex="0" aria-pressed="false">
+                          <img src="thumbnail_illust2.jpg" alt="Illustration preview 02" class="card wk-portal-image wk-deck-card" data-deck-index="1" role="button" tabindex="0" aria-pressed="false">
                           <div class="wk-portal-body">
                             <p class="wk-portal-lead">最近の1枚を、カードの手前に。</p>
                             <a class="wk-portal-link" href="https://x.com/wakadori_illust" data-wk-action="external" aria-label="wakadori illustration account on X (external link)" data-shelf-hide>
@@ -102,13 +102,13 @@
                     </ul>
                   </div>
                   <div class="wk-snapshots wk-deck" data-wk-deck="tech" data-wk-action="preview">
-                    <div class="wk-shot wk-deck-card" data-deck-index="0" role="button" tabindex="0" aria-pressed="false">
+                    <div class="card wk-shot wk-deck-card" data-deck-index="0" role="button" tabindex="0" aria-pressed="false">
                       <span class="wk-shot-label">UI Snapshot</span>
                       <div class="wk-shot-frame">
                         <img src="thumbnail_tech.jpg" alt="UI sample" class="wk-shot-preview">
                       </div>
                     </div>
-                    <div class="wk-shot wk-deck-card" data-deck-index="1" role="button" tabindex="0" aria-pressed="false">
+                    <div class="card wk-shot wk-deck-card" data-deck-index="1" role="button" tabindex="0" aria-pressed="false">
                       <span class="wk-shot-label">Code Notes</span>
                       <div class="wk-shot-frame">
                         <img src="thumbnail_tech2.jpg" alt="UI sample 2" class="wk-shot-preview">


### PR DESCRIPTION
## Summary
- スマホ実装をカード憲法 #53 に照合し、条項⑩「.card クラスで明示」の欠如を修正
- deck card 要素（illustration preview, tech shot）に `.card` クラスを追加
- 他9条項は既に準拠済み

## Test plan
- [x] スマホ: タップでpeek overlay開閉
- [x] スマホ: 縦スクロール正常
- [x] VoiceOver/TalkBack でボタン読み上げ
- [x] reduced-motion でアニメ抑制
- [x] PC: tilt/flip動作維持
- [x] PC棚モード: `data-shelf-hide` 挙動維持

Ref: #53, #54
Closes: #54