### PR TITLE
ci: add guarded Pages deployment workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,6 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: node --test tests/ci/*.test.mjs
       - run: npm run lint
       - run: npm run format:check

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,159 @@
+name: Pages Deploy
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  deployments: write
+  pull-requests: read
+
+jobs:
+  authorize:
+    name: Authorize immutable CI output
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (
+        (github.event.workflow_run.event == 'pull_request' &&
+          vars.PAGES_PREVIEW_DEPLOY_ENABLED == 'true') ||
+        (github.event.workflow_run.event == 'push' &&
+          vars.PAGES_PRODUCTION_DEPLOY_ENABLED == 'true')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      allowed: ${{ steps.gate.outputs.allowed }}
+      artifact_name: ${{ steps.gate.outputs.artifact_name }}
+      branch: ${{ steps.gate.outputs.branch }}
+      environment: ${{ steps.gate.outputs.environment }}
+      sha: ${{ steps.gate.outputs.sha }}
+    steps:
+      - name: Validate repository, actor, event, and SHA
+        id: gate
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
+            const fail = (message) => {
+              core.setOutput("allowed", "false");
+              core.setFailed(message);
+            };
+
+            if (run.conclusion !== "success") {
+              return fail(`CI conclusion is ${run.conclusion}`);
+            }
+            if (run.head_repository?.full_name !== expectedRepository) {
+              return fail(`CI head repository is not ${expectedRepository}`);
+            }
+
+            let branch;
+            let environment;
+            let sha;
+
+            if (run.event === "push") {
+              if (run.head_branch !== "main") {
+                return fail("Only successful main pushes may deploy to production");
+              }
+              if (!/^[0-9a-f]{40}$/.test(run.head_sha)) {
+                return fail("CI head SHA is not a full commit SHA");
+              }
+
+              branch = "main";
+              environment = "production";
+              sha = run.head_sha;
+            } else if (run.event === "pull_request") {
+              if (run.actor?.login !== "wakadorimk2") {
+                return fail("Preview deploys are restricted to actor wakadorimk2");
+              }
+              if (!Array.isArray(run.pull_requests) || run.pull_requests.length !== 1) {
+                return fail("Expected exactly one pull request on the CI run");
+              }
+
+              const linked = run.pull_requests[0];
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: linked.number,
+              });
+
+              if (pull.state !== "open") {
+                return fail(`Pull request #${pull.number} is not open`);
+              }
+              if (pull.base.ref !== "main") {
+                return fail(`Pull request #${pull.number} does not target main`);
+              }
+              if (pull.head.repo?.full_name !== expectedRepository) {
+                return fail(`Pull request #${pull.number} does not originate in this repository`);
+              }
+              if (pull.head.sha !== run.head_sha) {
+                return fail(`Pull request #${pull.number} moved after this CI run`);
+              }
+              if (!/^[0-9a-f]{40}$/.test(pull.head.sha)) {
+                return fail(`Pull request #${pull.number} head is not a full commit SHA`);
+              }
+              if (!/^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/.test(pull.head.ref)) {
+                return fail("Pull request branch cannot be passed safely to Wrangler");
+              }
+
+              branch = pull.head.ref;
+              environment = "preview";
+              sha = pull.head.sha;
+            } else {
+              return fail(`Unsupported CI event: ${run.event}`);
+            }
+
+            core.setOutput("allowed", "true");
+            core.setOutput("artifact_name", `pages-deploy-bundle-${sha}`);
+            core.setOutput("branch", branch);
+            core.setOutput("environment", environment);
+            core.setOutput("sha", sha);
+
+  deploy:
+    name: Deploy verified Pages bundle
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: pages-${{ needs.authorize.outputs.environment }}
+      cancel-in-progress: false
+    environment:
+      name: ${{ needs.authorize.outputs.environment }}
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - name: Download the exact CI artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: ${{ needs.authorize.outputs.artifact_name }}
+          path: bundle
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Verify artifact structure and source revision
+        env:
+          EXPECTED_SHA: ${{ needs.authorize.outputs.sha }}
+        run: |
+          test -d bundle/dist
+          test -d bundle/functions
+          test -f bundle/pages-commit-sha.txt
+          test "$(wc -l < bundle/pages-commit-sha.txt)" -eq 1
+          test "$(cat bundle/pages-commit-sha.txt)" = "$EXPECTED_SHA"
+
+      - name: Deploy without executing artifact code
+        id: deploy
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: 4.86.0
+          workingDirectory: bundle
+          command: >-
+            pages deploy dist
+            --project-name=wakadori-me
+            --branch=${{ needs.authorize.outputs.branch }}
+            --commit-hash=${{ needs.authorize.outputs.sha }}

--- a/.github/workflows/pages-preview-cleanup.yml
+++ b/.github/workflows/pages-preview-cleanup.yml
@@ -1,0 +1,45 @@
+name: Pages Preview Cleanup
+
+on:
+  schedule:
+    - cron: "17 18 * * *"
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Delete the listed deployments
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      vars.PAGES_PREVIEW_CLEANUP_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: preview
+    concurrency:
+      group: pages-preview-cleanup
+      cancel-in-progress: false
+    steps:
+      - name: Check out trusted default-branch cleanup code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+
+      - name: Plan or apply cleanup
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >-
+          node scripts/pages-preview-cleanup.mjs
+          ${{ github.event_name == 'schedule' && '--apply' || (inputs.apply && '--apply' || '') }}

--- a/docs/pages-deployment-runbook.md
+++ b/docs/pages-deployment-runbook.md
@@ -1,0 +1,73 @@
+# GitHub Actions / Cloudflare Pages 切替runbook
+
+GitHub Actionsを唯一の実行起点にし、既存のCloudflare Pagesプロジェクト
+`wakadori-me`へ検証済み成果物だけを送るための手順です。
+
+## このinfra変更の境界
+
+- `main`版の`CI`は既存のlint／formatを維持し、infra fixtureテストだけを追加する
+- `Pages Deploy`はdefault branch上の`workflow_run`から起動する
+- deploy対象は成功した`CI` runに紐づく`pages-deploy-bundle-<SHA>`だけに限定する
+- 現段階の`main`版`CI`はdeploy成果物を生成しない。PR #69側への成果物生成CI追加は、
+  このinfra変更がdefault branchへ入った後の別工程とする
+- PR Previewは同一repository、actor `wakadorimk2`、open PR、base `main`、
+  現在のPR HEADとCI runのSHA一致を要求する
+- 権限付きdeploy jobはPRをcheckoutせず、依存関係や成果物内スクリプトを実行しない
+- `pages-preview-cleanup.mjs`はdry-runが既定で、apply時は1件ずつDELETEし、
+  直後の管理API GETが404でなければ停止する
+- 3つのrepository variableが未設定の間、Preview／Production／定期cleanupは無効である
+
+## 事前設定
+
+GitHub Environmentsに`preview`と`production`を作成し、それぞれに以下のsecretを設定します。
+
+- `CLOUDFLARE_API_TOKEN`（対象Pages projectの読み書き）
+- `CLOUDFLARE_ACCOUNT_ID`
+
+Repository variablesは初期状態では未設定（すべて無効）にします。
+
+- `PAGES_PREVIEW_DEPLOY_ENABLED`: `true`のときだけPR Previewを許可する
+- `PAGES_PRODUCTION_DEPLOY_ENABLED`: `true`のときだけ`main` Productionを許可する
+- `PAGES_PREVIEW_CLEANUP_ENABLED`: `true`のときだけscheduleが実削除する
+
+手動cleanupは最後のvariableに関係なく起動できますが、`apply`の既定値は`false`です。
+
+Cloudflare Pages側では、切替前に次を設定・確認します。
+
+1. Git連携build commandを`npm run build`、output directoryを`dist`にして、
+   現行PRのGit連携Previewを正常化する
+2. Preview専用KV namespaceを`WK_CACHE`へ割り当てる
+3. Previewでは`PIXIV_PHPSESSID`と`GITHUB_TOKEN`を未設定にする
+4. Pages Preview Access policyを有効化し、Preview URLのみを認証必須にする
+5. 本番の`wakadori-me.pages.dev`と`wakadori.me`が公開のままか確認する
+
+リポジトリにWrangler設定ファイルを置いていないのは、既存Pages projectのDashboard設定を
+意図せず上書きしないためです。Preview/Productionのbindingとsecretは、切替時にDashboardの
+実値を再確認します。
+
+## 直列の切替ゲート
+
+各項目は前項が完了してから進め、失敗時は再試行や次工程への移行をしません。
+
+`workflow_run`はworkflow fileがdefault branchに存在するときだけ起動します。したがって、
+PR #69をmerge前に検証するには、このdeploy基盤をPR #69とは別のinfra変更として先に
+default branchへ載せる必要があります。その時点では3つのrepository variableを未設定にし、
+Production、Preview、定期cleanupのいずれも実行させません。
+
+1. deploy基盤だけのinfra変更について、対象ファイルとCIを確認し、別承認でdefault branchへ載せる
+2. PR #69をDraftのまま維持し、HEAD、CI、変更ファイルを再確認する
+3. PR #69の`CI`に、全検証成功後だけ`dist/`、`functions/`、対象SHAを
+   `pages-deploy-bundle-<SHA>`として7日間保存する工程を追加する
+4. Git連携Previewで固有URL、branch alias、Functions、Access、Preview KVを確認する
+5. 明示承認後、`PAGES_PREVIEW_DEPLOY_ENABLED=true`にしてPR #69のCIを対象HEADで実行する
+6. GitHub Actions Previewの固有URL、branch alias、Functions、Access、Preview KV、SHAを確認する
+7. cleanupを手動dry-runし、30日以内・Production・各branch最新が保持されることを確認する
+8. 必要なら別承認後に`PAGES_PREVIEW_CLEANUP_ENABLED=true`としてscheduleを有効化する
+9. 明示承認後、Cloudflareのautomatic production deploymentsを無効化する
+10. 同じ承認工程でPreview branchを`None`へ変更する
+11. Cloudflare設定の反映確認後、`PAGES_PRODUCTION_DEPLOY_ENABLED=true`にする
+12. その後に限り、別承認でPR #69をmergeする
+13. `main` CI由来のProduction deploymentと公開URLを確認する
+14. `/api/works`、`/api/repos`、`/img/pixiv/**`をsmoke testする
+
+切替完了までは旧Git連携設定を記録し、復元可能な状態を保ちます。

--- a/scripts/pages-preview-cleanup.mjs
+++ b/scripts/pages-preview-cleanup.mjs
@@ -1,0 +1,181 @@
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_PROJECT = "wakadori-me";
+const DEFAULT_RETENTION_DAYS = 30;
+const DAY_MS = 86_400_000;
+
+function deploymentBranch(deployment) {
+  return deployment.deployment_trigger?.metadata?.branch || null;
+}
+
+export function planPreviewCleanup(
+  deployments,
+  { now = new Date(), retentionDays = DEFAULT_RETENTION_DAYS } = {},
+) {
+  const cutoff = now.getTime() - retentionDays * DAY_MS;
+  const latestByBranch = new Map();
+
+  for (const deployment of deployments) {
+    if (deployment.environment !== "preview") continue;
+    const branch = deploymentBranch(deployment);
+    if (!branch) continue;
+
+    const current = latestByBranch.get(branch);
+    if (!current || new Date(deployment.created_on) > new Date(current.created_on)) {
+      latestByBranch.set(branch, deployment);
+    }
+  }
+
+  return deployments
+    .filter((deployment) => {
+      if (deployment.environment !== "preview") return false;
+      if (new Date(deployment.created_on).getTime() >= cutoff) return false;
+
+      const branch = deploymentBranch(deployment);
+      if (!branch) return false;
+      if (latestByBranch.get(branch)?.id === deployment.id) return false;
+      return true;
+    })
+    .sort((left, right) => new Date(left.created_on) - new Date(right.created_on));
+}
+
+function parseArguments(argv) {
+  const options = {
+    apply: false,
+    project: DEFAULT_PROJECT,
+    retentionDays: DEFAULT_RETENTION_DAYS,
+  };
+
+  for (const argument of argv) {
+    if (argument === "--apply") {
+      options.apply = true;
+    } else if (argument.startsWith("--project=")) {
+      options.project = argument.slice("--project=".length);
+    } else if (argument.startsWith("--retention-days=")) {
+      options.retentionDays = Number(argument.slice("--retention-days=".length));
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(options.project)) {
+    throw new Error("Project name contains unsupported characters");
+  }
+  if (!Number.isInteger(options.retentionDays) || options.retentionDays < 1) {
+    throw new Error("Retention days must be a positive integer");
+  }
+  return options;
+}
+
+function apiEndpoint(accountId, project, suffix = "") {
+  const encodedProject = encodeURIComponent(project);
+  return `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${encodedProject}/deployments${suffix}`;
+}
+
+async function cloudflareRequest(url, token, init = {}, request = fetch) {
+  return request(url, {
+    ...init,
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${token}`,
+      ...init.headers,
+    },
+  });
+}
+
+async function listDeployments(accountId, project, token, request) {
+  const deployments = [];
+
+  for (let page = 1; ; page += 1) {
+    const url = new URL(apiEndpoint(accountId, project));
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("per_page", "25");
+    const response = await cloudflareRequest(url, token, {}, request);
+    const body = await response.json();
+
+    if (!response.ok || body.success !== true || !Array.isArray(body.result)) {
+      throw new Error(`Deployment list failed with HTTP ${response.status}`);
+    }
+    deployments.push(...body.result);
+
+    const totalPages = body.result_info?.total_pages;
+    if (Number.isInteger(totalPages) ? page >= totalPages : body.result.length < 25) break;
+  }
+
+  return deployments;
+}
+
+async function deleteAndVerify(deployment, accountId, project, token, request) {
+  const suffix = `/${encodeURIComponent(deployment.id)}`;
+  const deleteUrl = new URL(apiEndpoint(accountId, project, suffix));
+  deleteUrl.searchParams.set("force", "true");
+  const deletion = await cloudflareRequest(deleteUrl, token, { method: "DELETE" }, request);
+  const deletionBody = await deletion.json();
+
+  if (!deletion.ok || deletionBody.success !== true) {
+    throw new Error(`DELETE ${deployment.id} failed with HTTP ${deletion.status}`);
+  }
+
+  const verification = await cloudflareRequest(
+    apiEndpoint(accountId, project, suffix),
+    token,
+    {},
+    request,
+  );
+  if (verification.status !== 404) {
+    throw new Error(`GET ${deployment.id} returned HTTP ${verification.status}; expected 404`);
+  }
+}
+
+export async function main(
+  argv = process.argv.slice(2),
+  env = process.env,
+  { now = new Date(), request = fetch, log = console.log } = {},
+) {
+  const options = parseArguments(argv);
+  const accountId = env.CLOUDFLARE_ACCOUNT_ID;
+  const token = env.CLOUDFLARE_API_TOKEN;
+
+  if (!accountId || !token) {
+    throw new Error("CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required");
+  }
+
+  const deployments = await listDeployments(accountId, options.project, token, request);
+  const candidates = planPreviewCleanup(deployments, {
+    now,
+    retentionDays: options.retentionDays,
+  });
+
+  log(
+    JSON.stringify(
+      {
+        mode: options.apply ? "apply" : "dry-run",
+        project: options.project,
+        retentionDays: options.retentionDays,
+        candidateCount: candidates.length,
+        candidates: candidates.map((deployment) => ({
+          id: deployment.id,
+          branch: deploymentBranch(deployment),
+          createdOn: deployment.created_on,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!options.apply) return;
+
+  for (const deployment of candidates) {
+    await deleteAndVerify(deployment, accountId, options.project, token, request);
+    log(`Deleted and verified ${deployment.id}`);
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tests/ci/pages-preview-cleanup.test.mjs
+++ b/tests/ci/pages-preview-cleanup.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { main, planPreviewCleanup } from "../../scripts/pages-preview-cleanup.mjs";
+
+const now = new Date("2026-07-23T00:00:00.000Z");
+
+function deployment(id, environment, branch, createdOn) {
+  return {
+    id,
+    environment,
+    created_on: createdOn,
+    deployment_trigger: branch ? { metadata: { branch } } : {},
+  };
+}
+
+test("keeps production, recent previews, and the latest preview for every branch", () => {
+  const deployments = [
+    deployment("production-old", "production", "main", "2025-01-01T00:00:00.000Z"),
+    deployment("feature-old", "preview", "feature/a", "2026-05-01T00:00:00.000Z"),
+    deployment("feature-latest", "preview", "feature/a", "2026-05-02T00:00:00.000Z"),
+    deployment("recent", "preview", "feature/b", "2026-07-10T00:00:00.000Z"),
+    deployment("branchless-old", "preview", null, "2026-05-03T00:00:00.000Z"),
+  ];
+
+  assert.deepEqual(
+    planPreviewCleanup(deployments, { now }).map(({ id }) => id),
+    ["feature-old"],
+  );
+});
+
+test("uses an exact 30-day cutoff", () => {
+  const deployments = [
+    deployment("older", "preview", "feature/a", "2026-06-22T23:59:59.999Z"),
+    deployment("at-cutoff", "preview", "feature/a", "2026-06-23T00:00:00.000Z"),
+    deployment("latest", "preview", "feature/a", "2026-07-01T00:00:00.000Z"),
+  ];
+
+  assert.deepEqual(
+    planPreviewCleanup(deployments, { now }).map(({ id }) => id),
+    ["older"],
+  );
+});
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function cleanupFixture() {
+  return [
+    deployment("delete-a", "preview", "feature/a", "2026-05-01T00:00:00.000Z"),
+    deployment("keep-a", "preview", "feature/a", "2026-07-01T00:00:00.000Z"),
+    deployment("delete-b", "preview", "feature/b", "2026-05-02T00:00:00.000Z"),
+    deployment("keep-b", "preview", "feature/b", "2026-07-02T00:00:00.000Z"),
+    deployment("delete-c", "preview", "feature/c", "2026-05-03T00:00:00.000Z"),
+    deployment("keep-c", "preview", "feature/c", "2026-07-03T00:00:00.000Z"),
+  ];
+}
+
+const cleanupEnv = {
+  CLOUDFLARE_ACCOUNT_ID: "account-id",
+  CLOUDFLARE_API_TOKEN: "test-token",
+};
+
+test("dry-run lists candidates without deleting", async () => {
+  const calls = [];
+  const logs = [];
+  const request = async (url, init) => {
+    calls.push({ url: String(url), method: init.method || "GET" });
+    return jsonResponse({
+      success: true,
+      result: cleanupFixture(),
+      result_info: { total_pages: 1 },
+    });
+  };
+
+  await main([], cleanupEnv, { now, request, log: (line) => logs.push(line) });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "GET");
+  assert.match(logs[0], /"mode": "dry-run"/);
+  assert.match(logs[0], /"candidateCount": 3/);
+});
+
+test("apply verifies every deletion with GET 404 and stops on the first failure", async () => {
+  const calls = [];
+  const request = async (url, init) => {
+    const parsed = new URL(url);
+    const method = init.method || "GET";
+    calls.push(`${method} ${parsed.pathname}`);
+
+    if (parsed.searchParams.has("page")) {
+      return jsonResponse({
+        success: true,
+        result: cleanupFixture(),
+        result_info: { total_pages: 1 },
+      });
+    }
+    if (method === "DELETE") return jsonResponse({ success: true, result: {} });
+    if (parsed.pathname.endsWith("/delete-a")) return jsonResponse({}, 404);
+    if (parsed.pathname.endsWith("/delete-b")) return jsonResponse({}, 200);
+    throw new Error("The third candidate must not be reached");
+  };
+
+  await assert.rejects(
+    main(["--apply"], cleanupEnv, { now, request, log: () => {} }),
+    /GET delete-b returned HTTP 200; expected 404/,
+  );
+
+  assert.deepEqual(
+    calls.slice(1).map((call) => call.split("/").at(-1)),
+    ["delete-a", "delete-a", "delete-b", "delete-b"],
+  );
+  assert.ok(calls.every((call) => !call.endsWith("/delete-c")));
+});

--- a/tests/ci/workflows.test.mjs
+++ b/tests/ci/workflows.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const readWorkflow = (name) =>
+  readFile(new URL(`../../.github/workflows/${name}`, import.meta.url), "utf8");
+
+test("CI preserves lint and format checks and runs the infrastructure fixtures", async () => {
+  const workflow = await readWorkflow("ci.yml");
+
+  assert.match(workflow, /node --test tests\/ci\/\*\.test\.mjs/);
+  assert.match(workflow, /npm run lint/);
+  assert.match(workflow, /npm run format:check/);
+  assert.doesNotMatch(workflow, /upload-artifact|pages-deploy-bundle/);
+});
+
+test("privileged deploy consumes one run-scoped artifact without checkout or install", async () => {
+  const workflow = await readWorkflow("pages-deploy.yml");
+
+  assert.doesNotMatch(workflow, /actions\/checkout|npm (ci|install)|\brun: node\b/);
+  assert.match(workflow, /run-id: \$\{\{ github\.event\.workflow_run\.id \}\}/);
+  assert.match(workflow, /vars\.PAGES_PREVIEW_DEPLOY_ENABLED == 'true'/);
+  assert.match(workflow, /vars\.PAGES_PRODUCTION_DEPLOY_ENABLED == 'true'/);
+  assert.match(workflow, /run\.head_repository\?\.full_name !== expectedRepository/);
+  assert.match(workflow, /run\.actor\?\.login !== "wakadorimk2"/);
+  assert.match(workflow, /pull\.head\.sha !== run\.head_sha/);
+  assert.match(workflow, /artifact_name", `pages-deploy-bundle-\$\{sha\}`/);
+  assert.match(workflow, /wranglerVersion: 4\.86\.0/);
+  assert.match(workflow, /cloudflare\/wrangler-action@[0-9a-f]{40}/);
+});
+
+test("manual cleanup defaults to dry-run and scheduled cleanup applies serially", async () => {
+  const workflow = await readWorkflow("pages-preview-cleanup.yml");
+
+  assert.match(workflow, /cron: "17 18 \* \* \*"/);
+  assert.match(workflow, /default: false/);
+  assert.match(workflow, /vars\.PAGES_PREVIEW_CLEANUP_ENABLED == 'true'/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /github\.event_name == 'schedule' && '--apply'/);
+});


### PR DESCRIPTION
## 概要

- 成功した `CI` の run-scoped artifact だけを受け取る、`workflow_run` ベースの Cloudflare Pages deploy workflow を追加
- Production、Preview、定期 cleanup を repository variable で既定無効化
- 30日より古い Preview を対象に、Production・30日以内・各branch最新を保持する cleanup スクリプトと fixture tests を追加
- 切替を直列ゲートで進める runbook を追加
- `main` 版 CI は既存 lint／format を維持し、infra fixture tests だけを追加

## 安全境界

- このPRのmergeだけでは Preview／Production deploy、定期cleanupを起動しない
- `.codex/config.toml`、Astro固有の `package.json`／Playwright変更、成果物生成CIは含めない
- PR #69は変更しない。PR #69向け成果物生成CIは、この基盤がdefault branchへ入った後の別工程とする
- Ready化、merge、Cloudflare設定変更、repository variable有効化は行わない

## 検証

- `node --test tests/ci/*.test.mjs`（7件成功）
- `npm run lint`
- `npm run format:check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --cached --check`
- 使用するGitHub Actionsの固定SHAと公式major tagの一致を確認