### PR TITLE
fix: スマホ向けヒーローレイアウトを調整

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -830,13 +830,14 @@ a {
   .hero {
     min-height: auto;
     grid-template-columns: 1fr;
-    gap: 4.5rem;
-    padding-block: 4rem 6rem;
+    gap: 4rem;
+    padding-block: 3.5rem 5rem;
   }
 
   .hero h1 {
     max-width: none;
-    font-size: clamp(3.2rem, 17vw, 5rem);
+    font-size: clamp(2.8rem, 13vw, 3.6rem);
+    text-wrap: balance;
   }
 
   .hero__copy > p[lang="en"] {
@@ -845,8 +846,12 @@ a {
   }
 
   .drawn-note--hero {
-    right: 1rem;
-    bottom: -2.8rem;
+    right: 0.5rem;
+    bottom: -2.4rem;
+  }
+
+  .hero__work::before {
+    inset: 8% 0 -4% 12%;
   }
 
   .hero__work > img {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -836,7 +836,7 @@ a {
 
   .hero h1 {
     max-width: none;
-    font-size: clamp(2.8rem, 13vw, 3.6rem);
+    font-size: clamp(2.4rem, 10.5vw, 3rem);
     text-wrap: balance;
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -855,8 +855,10 @@ a {
   }
 
   .hero__work > img {
+    height: auto;
     max-height: none;
     aspect-ratio: 4 / 5;
+    object-fit: contain;
   }
 
   .section-heading,

--- a/tests/portfolio.spec.ts
+++ b/tests/portfolio.spec.ts
@@ -29,6 +29,10 @@ test("keeps the mobile hero balanced and within the viewport", async ({ page }, 
 
     expect(headingLines.length, `${width}px heading lines`).toBeLessThanOrEqual(2);
     expect(headingLines.at(-1)?.length, `${width}px final heading line length`).toBeGreaterThan(2);
+    const headingFontSize = await page
+      .locator(".hero h1")
+      .evaluate((heading) => Number.parseFloat(getComputedStyle(heading).fontSize));
+    expect(headingFontSize, `${width}px heading font size`).toBeLessThanOrEqual(48);
 
     const layout = await page.evaluate(() => {
       const note = document.querySelector<HTMLElement>(".drawn-note--hero");

--- a/tests/portfolio.spec.ts
+++ b/tests/portfolio.spec.ts
@@ -1,5 +1,70 @@
 import { expect, test } from "@playwright/test";
 
+test("keeps the mobile hero balanced and within the viewport", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "mobile-360", "Covered once across mobile widths.");
+
+  for (const width of [320, 360, 440]) {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto("/");
+
+    const headingLines = await page.locator(".hero h1").evaluate((heading) => {
+      const textNode = heading.firstChild;
+      if (!textNode || textNode.nodeType !== Node.TEXT_NODE) return [];
+
+      const lines: Array<{ top: number; text: string }> = [];
+      for (let index = 0; index < (textNode.textContent?.length ?? 0); index += 1) {
+        const character = textNode.textContent?.at(index) ?? "";
+        if (!character.trim()) continue;
+
+        const range = document.createRange();
+        range.setStart(textNode, index);
+        range.setEnd(textNode, index + 1);
+        const top = range.getBoundingClientRect().top;
+        const line = lines.find((candidate) => Math.abs(candidate.top - top) < 1);
+        if (line) line.text += character;
+        else lines.push({ top, text: character });
+      }
+      return lines.map(({ text }) => text);
+    });
+
+    expect(headingLines.length, `${width}px heading lines`).toBeLessThanOrEqual(2);
+    expect(headingLines.at(-1)?.length, `${width}px final heading line length`).toBeGreaterThan(2);
+
+    const layout = await page.evaluate(() => {
+      const note = document.querySelector<HTMLElement>(".drawn-note--hero");
+      const heading = document.querySelector<HTMLElement>(".hero h1");
+      const englishCopy = document.querySelector<HTMLElement>('.hero__copy > p[lang="en"]');
+      const workImage = document.querySelector<HTMLElement>(".hero__work > img");
+      if (!note || !heading || !englishCopy || !workImage) return null;
+
+      const noteRect = note.getBoundingClientRect();
+      const overlaps = (element: HTMLElement) => {
+        const rect = element.getBoundingClientRect();
+        return !(
+          noteRect.right <= rect.left ||
+          noteRect.left >= rect.right ||
+          noteRect.bottom <= rect.top ||
+          noteRect.top >= rect.bottom
+        );
+      };
+
+      return {
+        hasHorizontalOverflow:
+          document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        overlapsHeading: overlaps(heading),
+        overlapsEnglishCopy: overlaps(englishCopy),
+        overlapsWorkImage: overlaps(workImage),
+      };
+    });
+
+    expect(layout, `${width}px hero elements`).not.toBeNull();
+    expect(layout?.hasHorizontalOverflow, `${width}px horizontal overflow`).toBe(false);
+    expect(layout?.overlapsHeading, `${width}px note/heading overlap`).toBe(false);
+    expect(layout?.overlapsEnglishCopy, `${width}px note/English copy overlap`).toBe(false);
+    expect(layout?.overlapsWorkImage, `${width}px note/work image overlap`).toBe(false);
+  }
+});
+
 test("shows the curated six works and opens a detail page", async ({ page }) => {
   await page.goto("/");
 

--- a/tests/portfolio.spec.ts
+++ b/tests/portfolio.spec.ts
@@ -6,6 +6,12 @@ test("keeps the mobile hero balanced and within the viewport", async ({ page }, 
   for (const width of [320, 360, 440]) {
     await page.setViewportSize({ width, height: 900 });
     await page.goto("/");
+    const workImage = page.locator(".hero__work > img");
+    await expect
+      .poll(() =>
+        workImage.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth > 0),
+      )
+      .toBe(true);
 
     const headingLines = await page.locator(".hero h1").evaluate((heading) => {
       const textNode = heading.firstChild;
@@ -55,6 +61,9 @@ test("keeps the mobile hero balanced and within the viewport", async ({ page }, 
       return {
         hasHorizontalOverflow:
           document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        imageAspectRatio:
+          workImage.getBoundingClientRect().width / workImage.getBoundingClientRect().height,
+        imageObjectFit: getComputedStyle(workImage).objectFit,
         overlapsHeading: overlaps(heading),
         overlapsEnglishCopy: overlaps(englishCopy),
         overlapsWorkImage: overlaps(workImage),
@@ -63,6 +72,8 @@ test("keeps the mobile hero balanced and within the viewport", async ({ page }, 
 
     expect(layout, `${width}px hero elements`).not.toBeNull();
     expect(layout?.hasHorizontalOverflow, `${width}px horizontal overflow`).toBe(false);
+    expect(layout?.imageAspectRatio, `${width}px image aspect ratio`).toBeCloseTo(4 / 5, 2);
+    expect(layout?.imageObjectFit, `${width}px image object-fit`).toBe("contain");
     expect(layout?.overlapsHeading, `${width}px note/heading overlap`).toBe(false);
     expect(layout?.overlapsEnglishCopy, `${width}px note/English copy overlap`).toBe(false);
     expect(layout?.overlapsWorkImage, `${width}px note/work image overlap`).toBe(false);


### PR DESCRIPTION
## 概要

640px以下のヒーローレイアウトを整え、見出し末尾の孤立・数pxの横スクロール・作品画像の上下クロップを解消します。

## 変更内容

- モバイル見出しを `clamp(2.4rem, 10.5vw, 3rem)` と `text-wrap: balance` で最大2行に調整
- ヒーローの上下余白と、コピー・作品画像間の間隔を縮小
- 手描き注釈を見出し・英文・作品画像と重ならない位置へ調整
- モバイル時の光彩の右側負 inset を除去し、横方向オーバーフローを防止
- 640px以下のヒーロー画像を `height: auto`・`object-fit: contain` にし、4:5枠内へ全体を表示
- 320px・360px・440px の回帰テストを追加

## 原因

モバイル見出しの文字サイズが画面幅に対して大きく、末尾の「る。」が孤立していました。また、作品画像背面の光彩に右側の負 inset が指定され、横方向のオーバーフローが発生し得る状態でした。

ヒーロー画像は縦長の元画像を `object-fit: cover` で4:5枠へ表示していたため上下がクロップされていました。さらにHTMLの `height` 属性がモバイルで未上書きだったため、`height: auto` を明示して4:5の表示領域を成立させています。

## 影響範囲

ヒーローの640px以下のスタイルと、その回帰テストのみです。コピー、作品データ、公開API、641px以上の `cover` 表示は変更していません。

## 検証

- `npm run check`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run test:e2e`（15 passed / 3 skipped）
- 320px・360px・440px で見出し行数、最大48px、横スクロールなし、注釈非重複を確認
- 同3幅で画像読み込み後の4:5表示領域と算出済み `object-fit: contain` を確認
